### PR TITLE
Implement Send for BsrrRef

### DIFF
--- a/src/interfaces/gpio/mod.rs
+++ b/src/interfaces/gpio/mod.rs
@@ -309,6 +309,8 @@ impl OutputPin {
 #[derive(Debug, Clone)]
 struct BsrrRef(*mut WriteOnly<stm32f7::BitSetResetRegister>);
 
+unsafe impl Send for BsrrRef {}
+
 impl BsrrRef {
     fn set(&self, pin: Pin, value: bool) {
         let mut bsrr = stm32f7::BitSetResetRegister::default();


### PR DESCRIPTION
This should be save (no data races), because GPIOx_BSRR is write only and writing a 0 has no effect. Writing a 1 will reset/set the corresponding ODRx bit.